### PR TITLE
sort wildcard include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include .configs*
+include $(sort $(wildcard .configs*))
 export $(shell sed 's/=.*//' .configs*)
 
 SHELL := /bin/bash


### PR DESCRIPTION
Make >3.82, <4.3 doesn't sort wildcards by default. That means that `.configs.user` can be included before `.configs` and effectively have everything overridden to the defaults.

This explicitly sorts the included files to prevent that.

This should fix #18