### PR TITLE
ignore top-level dynamic inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ve/
 *.retry
 configs/.configs.*
 ansible/dynamic-inventory/gce.ini
+dynamic-inventory/gce.ini


### PR DESCRIPTION
On my machine at least, it creates it at the top level, not in `ansible/dynamic-inventory`

This may also need to be changed in `scripts/local.sh` where it tries to delete `ansible/dynamic-inventory/gce.ini`, which also fails on my machine. I assume there's a cross-platform issue or something where the task in `ansible/local.yml` that writes to a `dest` of `dynamic-inventory/gce.ini` interprets that as relative to the playbook vs to the current working directory that `ansible-playbook` was called from.