### PR TITLE
create virtual env only if it doesn't exist

### DIFF
--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -61,7 +61,7 @@ requirements() {
 
 	message "Installing project requirements..." "ve/"
 	touch requirements.txt
-	virtualenv -p python3 ve &> "$SHELL_OUTPUT"
+	test -f ve/bin/python || virtualenv -p python3 ve &> "$SHELL_OUTPUT"
 	"$PIP" install -r requirements.txt&> "$SHELL_OUTPUT"
   configure_inventory
 }

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -71,8 +71,8 @@ clean() {
   # Cleans software and directory caches.                                     #
   #############################################################################
 	message "Flush pip packages..."
-	rm -rf ve
-	rm ansible/dynamic-inventory/gce.ini || printf '\n'
+	test -f ve/.keepme || rm -rf ve
+	rm -rf ansible/dynamic-inventory/gce.ini || printf '\n'
 
 	# Installing local environment requirements
 	requirements


### PR DESCRIPTION
don't assume that `python3` is available globally on the developer environment, so allow for an alternative to be provided by manually creating a virtual environment.

@ahmedaljazzar are there any other mentions of `python3` that would need to be converted to use the `ve/bin/python3`?