### PR TITLE
Restrict access to certain ports

### DIFF
--- a/configs/.configs
+++ b/configs/.configs
@@ -27,6 +27,14 @@ DENY_FIREWALL=deny-$INSTANCE_NAME-webserver-access
 # (DON'T CHANGE) The name of the allow rule on GCP firewall.
 ALLOW_FIREWALL=allow-$INSTANCE_NAME-webserver-access
 
+# (DON'T CHANGE unless necessary) The list of ports to be exposed:
+# lms:18000,studio:18010, forum:44567, discovery:18381, ecommerce:18130,
+# credentials:18150, edx_notes_api:18120, frontend-app-publisher:18400,
+# gradebook:1994, registrar:18734, program-console:1976,
+# frontend-app-learning:2000, frontend-app-library-authoring:3001,
+# course-authoring:2001, xqueue:18040, amc:13000
+EXPOSED_PORTS=22,18000,18010,44567,13000
+
 # The size of the disk your instance is going to use in GB. We don't recommend it to be less than 50.
 DISK_SIZE=200
 

--- a/scripts/configurations.sh
+++ b/scripts/configurations.sh
@@ -98,6 +98,7 @@ debug() {
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  ALLOW_FIREWALL" "$ALLOW_FIREWALL"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  DENY_FIREWALL" "$DENY_FIREWALL"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  RESTRICT_INSTANCE" "$RESTRICT_INSTANCE"
+  printf "${CYAN}%-30s${NORMAL} %-10s\n" "  EXPOSED_PORTS" "$EXPOSED_PORTS"
 
   printf "${PURPLE}%-30s${NORMAL}\n" "Google Cloud Platform"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  PROJECT_ID" "$PROJECT_ID"

--- a/scripts/firewall.sh
+++ b/scripts/firewall.sh
@@ -107,13 +107,17 @@ _create_allow_firewall() {
     MY_PUBLIC_IP="0.0.0.0/0"
   fi
 
+    # Processing instance ports
+    RULES=$( echo "tcp:$EXPOSED_PORTS" | sed  -e 's/,/,tcp:/g')
+
 	message "Creating ALLOW firewall rule in gcp..." "$ALLOW_FIREWALL:$MY_PUBLIC_IP"
+	message "Restricting ports access..." "$EXPOSED_PORTS"
 	(gcloud compute firewall-rules create "$ALLOW_FIREWALL" \
 		--quiet \
 		--verbosity "$VERBOSITY" \
 		--action allow \
 		--direction ingress \
-		--rules tcp \
+		--rules "$RULES" \
 		--source-ranges "$MY_PUBLIC_IP" \
 		--priority 50 \
 		--target-tags="$INSTANCE_TAG"\


### PR DESCRIPTION
Restricts port access in Sultan instances to edx-only ports. The list of ports we have is:

| Service                                         | Port       | Role         |
|--------------------------------|---------|----------|
| `ssh`                                            | 22           | Machine |
| `lms`                                            | 18000    | Default   |
| `studio`                                       | 18010     | Default   |
| `forum`                                        | 44567    | Default  |
| `amc`                                           | 22           | Extra      |

Solves #38 