### PR TITLE
Configure env variables during session login

### DIFF
--- a/ansible/roles/devstack/tasks/main.yml
+++ b/ansible/roles/devstack/tasks/main.yml
@@ -63,3 +63,17 @@
     path: "/etc/profile"
     block: "export DEVSTACK_USER={{ user_home }}"
   tags: [ server, reconfiguration ]
+
+- name: Configure .profile file
+  blockinfile:
+    path: "{{ home_dir }}/.profile"
+    block: |
+      export DEVSTACK_WORKSPACE={{ working_directory }}
+      export VIRTUAL_ENV={{ virtual_env_dir }}
+      export OPENEDX_RELEASE={{ openedx_release }}
+
+      source {{ virtual_env_dir }}/bin/activate
+      cd $DEVSTACK_WORKSPACE
+    marker: "# {mark} SULTAN MANAGED BLOCK"
+
+  tags: [ server, reconfiguration ]

--- a/scripts/instance.sh
+++ b/scripts/instance.sh
@@ -120,7 +120,7 @@ deploy() {
     # shellcheck disable=SC1090
     ansible-playbook "$sultan_dir"/ansible/devstack.yml \
       -i "$INVENTORY" \
-      -e "instance_name=$INSTANCE_NAME working_directory=$DEVSTACK_WORKSPACE git_repo_url=$DEVSTACK_REPO_URL openedx_release=$OPENEDX_RELEASE git_repo_branch=$DEVSTACK_REPO_BRANCH virtual_env_dir=$VIRTUAL_ENV" &> "$SHELL_OUTPUT"
+      -e "home_dir=$HOME_DIR instance_name=$INSTANCE_NAME working_directory=$DEVSTACK_WORKSPACE git_repo_url=$DEVSTACK_REPO_URL openedx_release=$OPENEDX_RELEASE git_repo_branch=$DEVSTACK_REPO_BRANCH virtual_env_dir=$VIRTUAL_ENV" &> "$SHELL_OUTPUT"
         success "Your virtual machine has been deployed successfully!"
         message "Run ${BOLD}${CYAN}sultan instance provision${NORMAL}${MAGENTA} to start provisioning your devstack."
 }
@@ -222,7 +222,7 @@ _image_setup() {
 	ansible-playbook "$sultan_dir"/ansible/devstack.yml \
 		-i "$INVENTORY" \
 		--tags "reconfiguration,never"  \
-		-e "instance_name=$INSTANCE_NAME user=$USER_NAME working_directory=$DEVSTACK_WORKSPACE" &> "$SHELL_OUTPUT"
+		-e "openedx_release=$OPENEDX_RELEASE virtual_env_dir=$VIRTUAL_ENV home_dir=$HOME_DIR instance_name=$INSTANCE_NAME user=$USER_NAME working_directory=$DEVSTACK_WORKSPACE" &> "$SHELL_OUTPUT"
 
 	success "Your instance has been successfully created!" "From $IMAGE_NAME"
 	message "Run ${BOLD}${CYAN}sultan devstack up${NORMAL}${MAGENTA} to start devstack servers."


### PR DESCRIPTION
This is a feature requested by the team to make it easier to interact with the devstack without having to configure all he environment variables on every session login. Once you ssh into the machine the following env will be exported, and we will change the directory to `~/workspace`.

```shell
export DEVSTACK_WORKSPACE=$DEVSTACK_WORKSPACE
export VIRTUAL_ENV=$VIRTUAL_ENV
export OPENEDX_RELEASE=$OPENEDX_RELEASE

source $VIRTUAL_ENV/bin/activate
```