### PR TITLE
Adding support to preemptible machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,49 @@ SERVICE_KEY_PATH=/Users/matej/Work/Appsembler/appsembler-devstack-30-104c123267b
 
 ### 3.3. Optional configurations
 
+#### Preemptible machine
+Preemptible VMs are highly affordable, short-lived compute instances suitable 
+for fault-tolerant workloads. They offer the same machine types and options as 
+regular compute instances and last for up to 24 hours, and can reduce your 
+Compute Engine costs by up to 80%!
+
+Sultan allows you to setup a preemptible machine, you can do that by setting
+the configuration variable `PREEMPTIBLE` to `true`. Just something to note 
+here, preemptible machines are not suitable for long provisioning work, we only 
+recommend using them with `sultan instance setup --image` command. If you 
+noticed a freeze in your machine's shell, it means that your machine got 
+interrupted, and you might have to restart the session again.
+
+#### Exposed ports
+For security reasons, Sultan firewall will restrict access to the ports in
+`EXPOSED_PORTS` in your .configs file. Here's the full list of the ports you
+might want to enable.
+
+> **NOTE**
+>
+> You need to run `sultan instance restrict` everytime you change the port.
+
+
+| Service                          | Port  | Role    |
+|----------------------------------|-------|---------|
+| `ssh`                            | 22    | Machine |
+| `lms`                            | 18000 | Default |
+| `studio`                         | 18010 | Default |
+| `forum`                          | 44567 | Default |
+| `amc`                            | 22    | Extra   |
+| `discovery`                      | 18381 | Default |
+| `ecommerce`                      | 18130 | Default |
+| `credentials`                    | 18150 | Default |
+| `edx_notes_api`                  | 18120 | Default |
+| `frontend-app-publisher`         | 18400 | Default |
+| `gradebook`                      | 1994  | Default |
+| `registrar`                      | 18734 | Extra   |
+| `program-console`                | 1976  | Extra   |
+| `frontend-app-learning`          | 2000  | Extra   |
+| `frontend-app-library-authoring` | 3001  | Extra   |
+| `course-authoring`               | 2001  | Extra   |
+| `xqueue`                         | 18040 | Extra   |
+
 #### Accessing `sultan` from any directory on your machine 
 If you want to access `sultan` command line from any directory, add this repo 
 dir to your `PATH`
@@ -355,26 +398,21 @@ again `sultan devstack mount`. Works like a charm.
 > But what I’ve found is that it works way way better with Visual Studio Code 
 > and its Code Remote Extensions.
 
-## 6. To conclude
-Please add more stuff to this doc as you discover helpful information. Let’s 
-all strive for a bright future where an engineer can follow a couple easy 
-steps here and BOOM it’s done.
-
-## 7. Environment variables
+## 6. Configurations variables
 We create a specific ignored .configs file for you when you ran `sultan config init`, 
-to debug the final environment variables values you can run
+to debug the interpreted values of your configs that sultan reads you can run
 ```console
 $ sultan config debug
 ```
 
-## 8. Tool help
+## 7. Tool help
 To check the commands documentation run
 ```console
 $ sultan -h
 $ sultan --help
 ```
 
-## 9. Errors
+## 8. Errors
 Errors are possible all the time. If an error's fired while executing commands 
 from this toolkit it is recommended to do a little bit more debugging.
 While this might be an issue with the tool, we just want you to make sure that 
@@ -395,7 +433,7 @@ TypeError: _clone() takes exactly 1 argument (3 given)
 ##### Instructions
 Omar: While I don’t know why this happening, I know how to fix it.
 
-Aparently devstack installs an incorrect `django-model-utils` package and it 
+Apparently, devstack installs an incorrect `django-model-utils` package that 
 breaks the LMS. Install a specific version of `jazzband/django-model-utils` so 
 the platform works:
 ```console
@@ -411,3 +449,8 @@ $ sultan devstack up
 ```
 
 That should fix the problem.
+
+## 9. To conclude
+Please add more stuff to this doc as you discover helpful information. Let’s 
+all strive for a bright future where an engineer can follow a couple easy 
+steps here and BOOM it’s done.

--- a/configs/.configs
+++ b/configs/.configs
@@ -52,6 +52,10 @@ SULTAN_HOME=$HOME/.sultan
 INVENTORY_CONFIGS_DIR=$SULTAN_HOME/ansible/dynamic-inventory
 INVENTORY=$INVENTORY_CONFIGS_DIR/inventory.compute.gcp.yml
 
+# Short-lived compute instances. Preemptible VMs offer the same machine types
+# and options as regular compute instances and last for up to 24 hours.
+PREEMPTIBLE=false
+
 # The mount location.
 MOUNT_DIR=$SULTAN_HOME/mnt/
 

--- a/scripts/configurations.sh
+++ b/scripts/configurations.sh
@@ -115,6 +115,7 @@ debug() {
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  INSTANCE_NAME" "$INSTANCE_NAME"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  INSTANCE_TAG" "$INSTANCE_TAG"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  MACHINE_TYPE" "$MACHINE_TYPE"
+  printf "${CYAN}%-30s${NORMAL} %-10s\n" "  PREEMPTIBLE" "$PREEMPTIBLE"
 
   printf "${PURPLE}%-30s${NORMAL}\n" "LOCAL"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  HOSTS_FILE" "$HOSTS_FILE"

--- a/scripts/firewall.sh
+++ b/scripts/firewall.sh
@@ -93,7 +93,7 @@ clean() {
   _delete_allow_firewall
   _delete_deny_firewall
 
-  success "Firewall rules has been cleaned from GCP"
+  success "Firewall rules have been cleaned from GCP"
 }
 
 _create_allow_firewall() {


### PR DESCRIPTION
We used to support preemptible machines in v1, but I dropped the support because it confuses sultan users when their machines get interrupted. 
Dropping support is not optimal, so here we add it again, but defaulting the build to `false`.  EdX operations usually takes long time (especially `dev.provision`), which is a good period of time to allow Google to interrupt the machine process, an interruption that forces us to redo the provisioning again and again. The best use case of these machines would be by using the image setup, fast process, and not a too long one, which gives it a higher chance of not getting interrupted. 

Solves #41