### PR TITLE
Automatically power off the machine after a certain amount of time

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ recommend using them with `sultan instance setup --image` command. If you
 noticed a freeze in your machine's shell, it means that your machine got 
 interrupted, and you might have to restart the session again.
 
+#### Machine lifespan
+When you create a sultan instance, the instance will be configured to run for 
+a specific amount of time configured in `ALIVE_TIME` in the configurations 
+file. We sat the default lifespan to 6 hours, when your machine powers off
+you can start it again using 
+```
+$ sultan instance start
+```
+
+To stop the machine manually before the timeout use
+```shell
+$ sultan instance stop
+```
+
 #### Exposed ports
 For security reasons, Sultan firewall will restrict access to the ports in
 `EXPOSED_PORTS` in your .configs file. Here's the full list of the ports you

--- a/configs/.configs
+++ b/configs/.configs
@@ -56,6 +56,10 @@ INVENTORY=$INVENTORY_CONFIGS_DIR/inventory.compute.gcp.yml
 # and options as regular compute instances and last for up to 24 hours.
 PREEMPTIBLE=false
 
+# The time the machine will be alive before a shutdown trigger gets fired.
+# We default it to 6 hours.
+ALIVE_TIME="$(expr 6 \* 60 \* 60)"
+
 # The mount location.
 MOUNT_DIR=$SULTAN_HOME/mnt/
 

--- a/scripts/configurations.sh
+++ b/scripts/configurations.sh
@@ -116,6 +116,7 @@ debug() {
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  INSTANCE_TAG" "$INSTANCE_TAG"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  MACHINE_TYPE" "$MACHINE_TYPE"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  PREEMPTIBLE" "$PREEMPTIBLE"
+  printf "${CYAN}%-30s${NORMAL} %-10s\n" "  ALIVE_TIME" "$ALIVE_TIME seconds"
 
   printf "${PURPLE}%-30s${NORMAL}\n" "LOCAL"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  HOSTS_FILE" "$HOSTS_FILE"

--- a/scripts/instance.sh
+++ b/scripts/instance.sh
@@ -117,6 +117,7 @@ create() {
 	    "--zone=$ZONE"
 	    "--verbosity=$VERBOSITY"
 	    "--project=$PROJECT_ID"
+      "--metadata=startup-script=/bin/bash -c '( sleep $ALIVE_TIME; sudo poweroff -p --no-wall ) &'"
     )
 
 


### PR DESCRIPTION
This change will bring all machines to a `TERMINATED` status in GCP. Another attempt to enhance the security of the instances and to avoid unnecessary charges if the were abandoned.

To test this, change `ALIVE_TIME` to a small value like 400 and then run 
```
$ sultan instance setup --image devstack-juniper
```

Another fix for #41