### PR TITLE
Update hosts configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,37 +251,30 @@ $ curl -I edx.devstack.lms:18010  ## Curls your LMS site.
 
 Our Devstack automatically creates your initial site:
 
-| Property | Value               |
-|:---------|:--------------------|
-| LMS URL  | red.localhost:18000 |
-| Username | red                 |
-| Email    | red@example.com     |
-| Password | red                 |
-
-
-> **Hey, I cannot access red.localhost:18000!**
->
-> Are you using Chrome? I was too. For some godforsaken reason it doesn’t work for me there (other URLs that are not localhost do). But in Firefox it does!
+| Property  | Value           |
+|:----------|:----------------|
+| LMS Port  | 18000           |
+| Username  | red             |
+| Email     | red@example.com |
+| Password  | red             |
 
 
 Other information:
 
-| Property                              | Value                                         |
-|:--------------------------------------|:----------------------------------------------|
-| AMC URL (Django-served)               | http://tahoe.devstack.amc:29000               |
-| AMC Signup Wizard URL (Django-served) | http://tahoe.devstack.amc:29000/signup-wizard |
-| LMS admin username                    | edx                                           |
-| LMS admin password                    | edx                                           |
-| AMC admin username                    | amc                                           |
-| AMC admin password                    | amc                                           |
-| Studio URL                            | http://amc.devstack.cms:18010                 |
+| Property                 | Value                       |
+|:-------------------------|:----------------------------|
+| Studio Port              | 18010                       |
+| EDX admin username       | edx                         |
+| EDX admin password       | edx                         |
+| AMC Port (Django-served) | 29000                       |
+| AMC Signup Wizard URL    | <domain:29000>/signup-wizard |
+| AMC admin username       | amc                         |
+| AMC admin password       | amc                         |
+
 
 ### 4.3. Optionally create your own site
-During the config we have added a `test.localhost` entry. So if you create a 
-new site just set the site name to `test` and you’ll automatically be 
-good to go.
-
-To skip the wizard and to create your site from command line (Good as it doesn't require email)   
+You can skip AMC's create site wizard, and create your site from command line
+(Good as it doesn't require email verification)   
 
 ```console
 $ sultan devstack make lms-shell

--- a/ansible/local.yml
+++ b/ansible/local.yml
@@ -6,10 +6,9 @@
       blockinfile:
         path: /etc/hosts
         block: |
-          {{ IP_ADDRESS }} {{ item }}
-        marker: "# {mark} SULTAN MANAGED BLOCK {{ item }}"
+          {{ IP_ADDRESS }} {{ EDX_HOST_NAMES }}
+        marker: "# {mark} SULTAN MANAGED HOST"
       become: yes
-      with_items: "{{ EDX_HOST_NAMES.split(',') }}"
       tags: [ hosts_update ]
 
     - name: Remove SSH configurations
@@ -18,16 +17,14 @@
         path: ~/.ssh/config
         marker: "# {mark} SULTAN MANAGED HOST"
         block: ""
-      become: yes
       tags: [ hosts_revert ]
 
     - name: Remove mappings from /etc/hosts
       blockinfile:
         path: /etc/hosts
-        marker: "# {mark} SULTAN MANAGED BLOCK {{ item }}"
+        marker: "# {mark} SULTAN MANAGED HOST"
         content: ""
       become: yes
-      with_items: "{{ EDX_HOST_NAMES.split(',') }}"
       tags: [ hosts_revert ]
 
     - name: Configure SSH agent forwarding

--- a/configs/.configs
+++ b/configs/.configs
@@ -66,8 +66,9 @@ MOUNT_DIR=$SULTAN_HOME/mnt/
 # (DON'T CHANGE) The hosts file location. You can change it for test purposes.
 HOSTS_FILE=/etc/hosts
 
-# A comma-separated list of hostnames you'd like to use.
-EDX_HOST_NAMES=edx.devstack.lms
+# A space-separated list of hostnames you would like to use to access the
+# remote machine.
+EDX_HOST_NAMES="edx.devstack.site tahoe.devstack.site edx.devstack.lms"
 
 # Determines whether to hide/show commands verbose output on the terminal
 DEBUG=false

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -122,7 +122,7 @@ hosts() {
              --connection=local \
              -i '127.0.0.1,' \
              --tags hosts_update \
-             -e "IP_ADDRESS=$IP_ADDRESS EDX_HOST_NAMES=$EDX_HOST_NAMES" "$sultan_dir"/ansible/local.yml > "$SHELL_OUTPUT" \
+             -e "IP_ADDRESS=$IP_ADDRESS EDX_HOST_NAMES='$EDX_HOST_NAMES'" "$sultan_dir"/ansible/local.yml > "$SHELL_OUTPUT" \
             || error "ERROR configuring hosts records."
     fi
     success "Your hosts have been configured successfully!"


### PR DESCRIPTION
These changes assume the `EDX_HOST_NAMES` configuration variable value is sat to a space-separated value instead of a comma-separated one. 

## Why the change?
- To help #45 configuring the cloudbuild /etc/hosts file in a clean way.
- Reduce clutter in your local /etc/hosts
- The first step to drop support for `*.localhost` domains as Chrome can't access them.
- Easy to read and to debug


## No changes required
If you forgot to remove the commas in `EDX_HOST_NAMES` from your `.configs.<user>` file, your configured hosts will still resolve to the machine, so no stress about this.
