### PR TITLE
fix escaping issue with startup script argument

### DIFF
--- a/scripts/instance.sh
+++ b/scripts/instance.sh
@@ -117,7 +117,7 @@ create() {
 	    "--zone=$ZONE"
 	    "--verbosity=$VERBOSITY"
 	    "--project=$PROJECT_ID"
-      "--metadata=startup-script=/bin/bash -c '( sleep $ALIVE_TIME; sudo poweroff -p --no-wall ) &'"
+            "--metadata=startup-script=\"/bin/bash -c '( sleep $ALIVE_TIME; sudo poweroff -p --no-wall ) &'"\"
     )
 
 


### PR DESCRIPTION
The added startup script argument added in #44 doesn't escape it properly, generating a `gcloud` command that has an argument like `--metadata=startup-script=/bin/bash -c '( sleep 21600; sudo poweroff -p --no-wall ) &'` which doesn't parse quite right. This just wraps it all in some quotes.