### PR TITLE
Error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ That should fix the problem.
 ├── ZONE
 ├── PREEMPTIBLE
 ├── ALIVE_TIME
+├── SSH_AGENT_HOST_NAME
 ├── HOSTS_FILE
 ├── IMAGE_FAMILY
 ├── EDX_HOST_NAMES

--- a/ansible/local.yml
+++ b/ansible/local.yml
@@ -33,7 +33,7 @@
         marker: "# {mark} SULTAN MANAGED HOST"
         create: yes
         block: |
-          Host devstack
+          Host {{ agent_host }}
             HostName {{ IP_ADDRESS }}
             User {{ USER }}
             IdentityFile {{ SSH_KEY }}

--- a/cloudbuild/build.sh
+++ b/cloudbuild/build.sh
@@ -19,7 +19,9 @@ apt-get install -y sudo
 
 export USER=cloudbuild
 export HOME=/root
-export TERM=dumb # make tput shut up
+export TERM=xterm-256color # make tput shut up
+
+eval "$(ssh-agent -s)" # Start the SSH agent
 
 # cloudbuild environment requires some trickiness
 mkdir /tmp/.ansible

--- a/cloudbuild/clean.sh
+++ b/cloudbuild/clean.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+set -eo pipefail
+
 export TERM=dumb # make tput shut up
+export TERM=xterm-256color # make tput shut up
 
 echo "Build script exited with status $PREVIOUS_EXIT"
 

--- a/cloudbuild/configs.juniper
+++ b/cloudbuild/configs.juniper
@@ -58,6 +58,9 @@ INVENTORY=$INVENTORY_CONFIGS_DIR/inventory.compute.gcp.yml
 # The mount location.
 MOUNT_DIR=$SULTAN_HOME/mnt/
 
+# The hostname for SSH agent forwarding rule in ~/.ssh/config
+SSH_AGENT_HOST_NAME=devstack
+
 # (DON'T CHANGE) The hosts file location. You can change it for test purposes.
 HOSTS_FILE=/etc/hosts
 

--- a/configs/.configs
+++ b/configs/.configs
@@ -70,6 +70,9 @@ ALIVE_TIME="$(expr 6 \* 60 \* 60)"
 # The mount location.
 MOUNT_DIR=$SULTAN_HOME/mnt/
 
+# The hostname for SSH agent forwarding rule in ~/.ssh/config
+SSH_AGENT_HOST_NAME=devstack
+
 # (DON'T CHANGE) The hosts file location. You can change it for test purposes.
 HOSTS_FILE=/etc/hosts
 

--- a/scripts/configurations.sh
+++ b/scripts/configurations.sh
@@ -124,6 +124,7 @@ debug() {
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  INVENTORY" "$INVENTORY"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  INVENTORY_CONFIGS_DIR" "$INVENTORY_CONFIGS_DIR"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  MOUNT_DIR" "$MOUNT_DIR"
+  printf "${CYAN}%-30s${NORMAL} %-10s\n" "  SSH_AGENT_HOST_NAME" "$SSH_AGENT_HOST_NAME"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  SSH_KEY" "$SSH_KEY"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  SULTAN_ENV" "$SULTAN_ENV"
   printf "${CYAN}%-30s${NORMAL} %-10s\n" "  SULTAN_HOME" "$SULTAN_HOME"

--- a/scripts/devstack.sh
+++ b/scripts/devstack.sh
@@ -70,9 +70,14 @@ stop()  {
   #############################################################################
   # Stops and unmounts a devstack servers.                                                   #
   #############################################################################
-  unmount
-  make stop
-	success "Your devstack stopped successfully."
+  if nc -z "$SSH_AGENT_HOST_NAME" 22 2>/dev/null; then
+    unmount
+    make stop
+    success "Your devstack stopped successfully."
+  else
+    warn "$SSH_AGENT_HOST_NAME is unreachable." "SKIPPING"
+    dim "This happens because of a misconfiguration in ${BOLD}~/.ssh/config${NORMAL}"
+  fi
 }
 
 mount() {

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -145,7 +145,7 @@ ssh() {
         --connection=local \
         -i '127.0.0.1,' \
         --tags ssh_config \
-        -e "IP_ADDRESS=$IP_ADDRESS USER=$USER_NAME SSH_KEY=$SSH_KEY" > "$SHELL_OUTPUT" \
+        -e "agent_host=$SSH_AGENT_HOST_NAME IP_ADDRESS=$IP_ADDRESS USER=$USER_NAME SSH_KEY=$SSH_KEY" > "$SHELL_OUTPUT" \
       || error "ERROR configuring SSH connection in your machine."
 
     ssh-add "$SSH_KEY"

--- a/sultan
+++ b/sultan
@@ -9,35 +9,35 @@ for f in "$current_dir"/configs/.configs* ; do
 done
 
 instance() {
-	"$current_dir"/scripts/instance.sh "$@"
+	bash -eo pipefail "$current_dir"/scripts/instance.sh "$@"
 }
 
 devstack() {
-	"$current_dir"/scripts/devstack.sh "$@"
+	bash -eo pipefail "$current_dir"/scripts/devstack.sh "$@"
 }
 
 workflow() {
-	"$current_dir"/scripts/workflow.sh "$@"
+	bash -eo pipefail "$current_dir"/scripts/workflow.sh "$@"
 }
 
 image() {
-	"$current_dir"/scripts/image.sh "$@"
+	bash -eo pipefail "$current_dir"/scripts/image.sh "$@"
 }
 
 firewall() {
-	"$current_dir"/scripts/firewall.sh "$@"
+	bash -eo pipefail "$current_dir"/scripts/firewall.sh "$@"
 }
 
 local() {
-	"$current_dir"/scripts/local.sh "$@"
+	bash -eo pipefail "$current_dir"/scripts/local.sh "$@"
 }
 
 config() {
-	"$current_dir"/scripts/configurations.sh "$@"
+	bash -eo pipefail "$current_dir"/scripts/configurations.sh "$@"
 }
 
 ci() {
-	"$current_dir"/scripts/ci.sh "$@"
+	bash -eo pipefail "$current_dir"/scripts/ci.sh "$@"
 }
 
 version() {


### PR DESCRIPTION
### Overview

- What sparked this PR? 
Some commands fail silently in a function without causing the script to stop. When fixing that, I watched an error when we try to stop devstack when the machine is not reachable.

- What problem does it solve? 
These changes will make it easier for us to debug and track errors down fast.

- Why is it useful?
CI builds should fail now whenever a sultan sub-script fails.

### Release notes 
- Sultan should exit immediately if a pipeline returns a non-zero status.
- You can specify the hostname for SSH agent forwarding rule in `~/.ssh/config` using `SSH_AGENT_HOST_NAME` config variable.

### Other 

- [x] Docs?
- [x] Tests?
