### PR TITLE
Update default host names to support default edX site creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ $ sultan instance ping  ## Verifies that Ansible is able to reach your instance.
 ```
 To verify that your devstack is running:
 ```console
-$ curl -I edx.devstack.lms:18010  ## Curls your LMS site.
+$ curl -I devstack.tahoe:18010  ## Curls your Studio site.
 ```
 
 > **NOTE**

--- a/cloudbuild/build.sh
+++ b/cloudbuild/build.sh
@@ -66,7 +66,7 @@ echo "Make sure the instance is pingable:"
 n=0
 HEARTBEAT=
 until [ "$n" -ge 5 ]; do
-  HEARTBEAT=$(curl -i -v http://edx.devstack.lms:18010/heartbeat) && break
+  HEARTBEAT=$(curl -i -v http://devstack.tahoe:18010/heartbeat) && break
   n=$((n + 1))
   sleep 30
 done

--- a/cloudbuild/configs.juniper
+++ b/cloudbuild/configs.juniper
@@ -64,8 +64,9 @@ SSH_AGENT_HOST_NAME=devstack
 # (DON'T CHANGE) The hosts file location. You can change it for test purposes.
 HOSTS_FILE=/etc/hosts
 
-# A comma-separated list of hostnames you'd like to use.
-EDX_HOST_NAMES=edx.devstack.lms
+# A space-separated list of hostnames you would like to use to access the
+# remote machine.
+EDX_HOST_NAMES="edx.devstack.lms devstack.tahoe"
 
 # Determines whether to hide/show commands verbose output on the terminal
 DEBUG=true
@@ -107,7 +108,7 @@ DEVSTACK_REPO_BRANCH=${DEVSTACK_BRANCH:-juniper}
 OPENEDX_RELEASE="juniper.master"
 
 # The command that runs all of your devstack services (LMS, Studio, ...) Change it if you have a custom one.
-DEVSTACK_RUN_COMMAND="HOST=tahoe.devstack.site dev.up"
+DEVSTACK_RUN_COMMAND="HOST=devstack.tahoe dev.up"
 
 # Whether to deny all IPs (except yours) from accessing your instance or not.
 RESTRICT_INSTANCE=true

--- a/configs/.configs
+++ b/configs/.configs
@@ -78,7 +78,7 @@ HOSTS_FILE=/etc/hosts
 
 # A space-separated list of hostnames you would like to use to access the
 # remote machine.
-EDX_HOST_NAMES="edx.devstack.site tahoe.devstack.site edx.devstack.lms"
+EDX_HOST_NAMES="edx.devstack.lms devstack.tahoe"
 
 # Determines whether to hide/show commands verbose output on the terminal
 DEBUG=false


### PR DESCRIPTION
### Overview

#### What sparked this PR? 
Provisioning devstack requires a hostname to be provided to create default sites on AMC and edX Platform. I switched from `edx.devstack.lms` to avoid confusion when connecting to other edX services, but I kept it as provisioning relies on it.

#### Why is it useful?
Allows Sultan to configure your machine to communicate with the created site.

### Release notes 
- Sultan now configures your machine to communicate with the default devstack site created during provisioning.

### Other 

- [x] Docs?
- [x] Tests?
