### PR TITLE
Fix underscore in cloudbuild and a README inaccuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,10 +278,10 @@ You can skip AMC's create site wizard, and create your site from command line
 
 ```console
 $ sultan devstack make lms-shell
-$ ./manage.py lms create_devstack_site test
+$ ./manage.py lms create_devstack_site <org> <host>  # your site will be available at org.host
 $ exit
 $ sultan devstack make amc-shell
-$ ./manage.py create_devstack_site test 
+$ ./manage.py create_devstack_site <org> <host>   # your site will be available at org.host
 $ exit
 ```
 

--- a/cloudbuild/configs.juniper
+++ b/cloudbuild/configs.juniper
@@ -17,7 +17,7 @@ HOST_NAME=$(hostname | tr '[:upper:]' '[:lower:]')
 # of firewall rules. Try to use a different one for each type
 # of environment we build so they can run simultaneously without
 # conflicting.
-INSTANCE_NAME=$(echo "$CUSTOM_INSTANCE_NAME" | sed 's/\//\-/g')
+INSTANCE_NAME=$(echo "$CUSTOM_INSTANCE_NAME" | sed 's/[\/_]/\-/g')
 
 # Default name of the image to create.
 IMAGE_NAME=devstack-$INSTANCE_NAME


### PR DESCRIPTION
### Overview

##### What sparked this PR?
#57 used a branch name that contains `_`, a character that's not allowed to be used in GCP resource names.
 
##### What problem does it solve? 
Because of that, tests are expected to fail for all branches that contain `_`s in them. This is a false negative indicator that should be handled after this merge.

### Release notes 
- Fix issue where tests on branches with `_`s fail to run.

### Other 

~- [ ] Docs?~
- [x] Tests?
