### PR TITLE
Bump ansible from 2.10.6 to 2.10.7

### DIFF
--- a/cloudbuild/configs.juniper
+++ b/cloudbuild/configs.juniper
@@ -17,7 +17,7 @@ HOST_NAME=$(hostname | tr '[:upper:]' '[:lower:]')
 # of firewall rules. Try to use a different one for each type
 # of environment we build so they can run simultaneously without
 # conflicting.
-INSTANCE_NAME=$(echo "$CUSTOM_INSTANCE_NAME" | sed 's/[\/_]/\-/g')
+INSTANCE_NAME=$(echo "dependabot/pip/ansible-2.10.7" | sed 's/[\/_\.]/\-/g')
 
 # Default name of the image to create.
 IMAGE_NAME=devstack-$INSTANCE_NAME

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 apache-libcloud==2.5.0
-ansible==2.10.6
+ansible==2.10.7
 google-auth==1.25.0
 requests==2.25.1


### PR DESCRIPTION
### Overview

- Picking #63 changes.
- replace the `.`s in the branch name with `-`s.
