### PR TITLE
Fix Alive Time configuration

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -44,7 +44,7 @@ build() {
 
 help() {
   # shellcheck disable=SC2059
-  printf "$help_text"
+  printf "$help_text" | less
 }
 
 # Print help message if command is not found

--- a/scripts/configurations.sh
+++ b/scripts/configurations.sh
@@ -135,7 +135,7 @@ debug() {
 
 help() {
   # shellcheck disable=SC2059
-  printf "$help_text"
+  printf "$help_text" | less
 }
 
 # Print help message if command is not found

--- a/scripts/devstack.sh
+++ b/scripts/devstack.sh
@@ -96,7 +96,7 @@ mount() {
 
 help() {
   # shellcheck disable=SC2059
-  printf "$help_text"
+  printf "$help_text" | less
 }
 
 # Print help message if command is not found

--- a/scripts/firewall.sh
+++ b/scripts/firewall.sh
@@ -157,7 +157,7 @@ allow() {
 
 help() {
   # shellcheck disable=SC2059
-  printf "$help_text"
+  printf "$help_text" | less
 }
 
 # Print help message if command is not found

--- a/scripts/image.sh
+++ b/scripts/image.sh
@@ -95,7 +95,7 @@ create() {
 
 help() {
   # shellcheck disable=SC2059
-  printf "$help_text"
+  printf "$help_text" | less
 }
 
 # Print help message if command is not found

--- a/scripts/instance.sh
+++ b/scripts/instance.sh
@@ -101,8 +101,9 @@ create() {
   # Creates an empty instance for you on GCP.                                 #
   #############################################################################
 
-  image="$IMAGE_NAME";
+  # shellcheck disable=SC2153
   alive_time="$ALIVE_TIME"
+  image="$IMAGE_NAME"
   while [[ "$#" -gt 0 ]]; do
     case $1 in
       -i|--image)

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -157,7 +157,7 @@ ssh() {
 
 help() {
   # shellcheck disable=SC2059
-  printf "$help_text"
+  printf "$help_text" | less
 }
 
 # Print help message if command is not found

--- a/scripts/workflow.sh
+++ b/scripts/workflow.sh
@@ -51,7 +51,7 @@ resume() {
 
 help() {
   # shellcheck disable=SC2059
-  printf "$help_text"
+  printf "$help_text" | less
 }
 
 # Print help message if command is not found


### PR DESCRIPTION
### Overview

Fixes #51 

This PR technically reverts the changes made in #47. The change introduced in that PR causes the startup-script on the machine to exit with status 127, and as a result, the instances stay alive and never terminate.
```
GCEMetadataScripts: Starting startup scripts (version 20201217.02-0ubuntu1~18.04.0).
GCEMetadataScripts: Found startup-script in metadata.
GCEMetadataScripts: startup-script: /tmp/metadata-scripts105166155/startup-script: line 1: /bin/bash -c '( sleep 21600; sudo poweroff -p --no-wall ) &': No such file or directory
GCEMetadataScripts: startup-script exit status 127
GCEMetadataScripts: Finished running startup scripts.
```

To make sure that these changes work, I introduced a test in our `build.sh` file that makes sure the instance is shutting down after a specified time. Also, to make this test handy, I introduced a flag to set the instance alive time which overrides the the default `ALIVE_TIME` configuration in case it's used.


### Verification
To verify that this change works, you need to create a new instance. In case you already have an instance (stopped or running) with some changes you want to keep, make sure to use the first and the last command

```console
foo@bar:~$ sultan image create --name <custom-name>  # Optional
foo@bar:~$ sultan instance setup --image devstack-juniper --alive-time 240

# Check after 240 seconds
foo@bar:~$ sultan instance status
TERMINATED

foo@bar:~$ sultan instance setup --image <custom-name>  # Optional
```

If you did not get a terminated status, please comment with the result of the following command
```console
foo@bar:~$ ssh devstack
user@sultan:~$ sudo grep startup /var/log/syslog

# Output should be similar to this
Apr 12 22:42:40 ahmedjazzar-at-macbook-pro-local GCEMetadataScripts[3670]: 2021/04/12 22:42:40 GCEMetadataScripts: Starting startup scripts (version 20201217.02-0ubuntu1~18.04.0).
Apr 12 22:42:40 ahmedjazzar-at-macbook-pro-local GCEMetadataScripts[3670]: 2021/04/12 22:42:40 GCEMetadataScripts: Found startup-script in metadata.
Apr 12 22:42:40 ahmedjazzar-at-macbook-pro-local GCEMetadataScripts[3670]: 2021/04/12 22:42:40 GCEMetadataScripts: startup-script: /tmp/metadata-scripts753366552/startup-script: line 1: /bin/bash -c '( sleep 21600; sudo poweroff -p --no-wall ) &': No such file or directory
Apr 12 22:42:40 ahmedjazzar-at-macbook-pro-local GCEMetadataScripts[3670]: 2021/04/12 22:42:40 GCEMetadataScripts: startup-script exit status 127
Apr 12 22:42:40 ahmedjazzar-at-macbook-pro-local GCEMetadataScripts[3670]: 2021/04/12 22:42:40 GCEMetadataScripts: Finished running startup scripts.
```

> **NOTE**
> If you ssh in the instance and run `sudo grep startup /var/log/syslog` before 240 seconds, you might see the above error as it's registered in the `devstack-juniper` image, so don't freak out, and try after the alive time period is passed.

### Release notes 

- Fix a bug where instances are not terminated themselves.
- `sultan instance create` and `sultan instance setup` now use `a, --alive-time` flag to override `ALIVE_TIME` value sat in your `.configs.<username>` file.
- Help commands now use less.

### Other 

- ~[ ] Docs?~
- [x] Tests?
