### PR TITLE
Fix bug where devstack stop command always fails

### DIFF
--- a/scripts/devstack.sh
+++ b/scripts/devstack.sh
@@ -70,7 +70,7 @@ stop()  {
   #############################################################################
   # Stops and unmounts a devstack servers.                                                   #
   #############################################################################
-  if nc -z "$SSH_AGENT_HOST_NAME" 22 2>/dev/null; then
+  if nc -z "$(sultan instance ip)" 22 2>/dev/null; then
     unmount
     make stop
     success "Your devstack stopped successfully."


### PR DESCRIPTION
### Overview

Calling `sultan devstack stop` always sends the **is unreachable** message, and that's not true for most of the cases. Netcat doesn't read `Hostname`s from ~/.ssh/config files, so we have to use the instance IP to check for connectivity.

### Release notes 
- Bug fixes
 
 
### Other 

- ~[ ] Docs?~
- ~[ ] Tests?~
