### PR TITLE
Fix start instance not working after instance is stopped

### DIFF
--- a/scripts/instance.sh
+++ b/scripts/instance.sh
@@ -194,11 +194,11 @@ start() {
 		--zone="$ZONE" \
 		--project "$PROJECT_ID"
 
-	$sultan local hosts config
-	$sultan local ssh config
-
 	# always restrict the instance after starting it.
 	restrict
+
+	$sultan local hosts config
+	$sultan local ssh config
 
 	success "Your virtual machine has been started successfully!"
 }


### PR DESCRIPTION
## Change description

After stopping sultan instance, starting it again will fail as the instance IP changed. Restricting the instance should happen directly after the instance starts, and before configuring the local machine ssh.

JIRA: [OT-516](https://appsembler.atlassian.net/browse/OT-516)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
