### PR TITLE
Add support for Edxapp Extra Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,43 @@ Yup, really works fast and resets it to that glorious state you saved. Nice.
 > The instance is secured behind a firewall by default. To override this 
 > behavior, change `RESTRICT_INSTANCE` value in your configs to `false`. 
 
+### 4.5. Adding extra requirements
+Sultan supports `EDXAPP_EXTRA_REQUIREMENTS` in its unique way. If you are not
+familiar with this variable, edX uses it in its production Ansible deployment
+scripts, but they were never incorporated in the devstack.
+
+We introduced a way in our devstack ([devstack#42](https://github.com/appsembler/devstack/pull/42))
+to install extra pip packages without modifying edx-platform codebase. This 
+variable has been added to Sultan as a comma-separated configuration variable 
+(`EDXAPP_EXTRA_REQUIREMENTS`), and it utilizes our `edxapp-pip` directory 
+to install extra packages. That's been said, this variable will have no effect
+on your devstack unless your using Appsembler's version of the 
+devstack, unfortunately.
+
+#### How to use it
+The configuration variable expects a comma-separated list of pip packages' 
+git repos:
+
+```shell
+EDXAPP_EXTRA_REQUIREMENTS="https://github.com/appsembler/gestore.git==0.1.0-dev3,https://github.com/appsembler/course-access-groups.git"
+```
+
+Once you finish adding this requirement, you need to apply it to the machine:
+- If you haven't created a machine yet, then you're all sit, the changes will be deployed in the next `sultan setup`.
+- If your machine is created and running, run `sultan instance deploy` to have these libraries cloned in your sultan instance.
+
+#### Specifying a package version
+To specify the version for your package, simply add `==<branch_or_tag>` after 
+the repo link. If no version is specified, we will default to the main branch 
+of the repo (`HEAD`).
+
+> **NOTE**
+> 
+> If the package you're installing is a Django app, then you might need to 
+> consider adding the app name to your `ADDL_INSTALLED_APPS` in your lms/cms 
+> YAML configs.
+
+
 ## 5. Development
 To change or update edx-platform code from your machine and reflect on the 
 server immediately, there are so many ways you can choose from. However, we 
@@ -478,7 +515,7 @@ That should fix the problem.
 │                          │                                  └── IMAGE_NAME
 ├── HOST_NAME ─────────────┘
 ├── PROJECT_ID
-├── EXPOSED_PORTS
+├── EDXAPP_EXTRA_REQUIREMENTS
 ├── BOOT_DISK_TYPE
 ├── DISK_SIZE
 ├── MACHINE_TYPE

--- a/ansible/roles/devstack/tasks/main.yml
+++ b/ansible/roles/devstack/tasks/main.yml
@@ -77,6 +77,22 @@
     marker: "# {mark} SULTAN MANAGED BLOCK"
   tags: [ server, reconfiguration ]
 
+- name: Install edxapp extra requirements
+  git:
+    repo: "{{ repo }}"
+    version: "{{ version }}"
+    dest: "{{ extra_requirements_directory }}/{{ package_name }}"
+    accept_hostkey: yes
+    key_file: yes
+  loop: "{{ extra_requirements.split(',') }}"
+  vars:
+    repo: "{{ item.split('==').0 }}"
+    package_name: "{{ repo | basename | regex_replace('^(.*).git$', '\\1') }}"
+    version: "{{ item.split('==').1 | default('HEAD') }}"
+  when: extra_requirements
+  become: no
+  tags: [ devstack, reconfiguration, env ]
+
 - name: Checkout Github branch
   git:
     repo: "{{ git_repo_url }}"

--- a/ansible/server-vars.yml
+++ b/ansible/server-vars.yml
@@ -1,4 +1,5 @@
 
+extra_requirements_directory: "{{ working_directory }}/src/edxapp-pip"
 devstack_directory: "{{ working_directory }}/devstack"
 
 ssh_keys_dir: "~/.ssh"

--- a/configs/.configs
+++ b/configs/.configs
@@ -119,6 +119,13 @@ DEVSTACK_REPO_BRANCH=open-release/juniper.master
 # To work on the master branches and latest images, unset OPENEDX_RELEASE or set it to an empty string.
 OPENEDX_RELEASE="${DEVSTACK_REPO_BRANCH//open-release\//}"
 
+# A comma-separated list of extra requirements to install inside your edxapp. This is an
+# alternative to the EDXAPP_EXTRA_REQUIREMENTS in edX Ansible scripts. At the moment
+# We only support cloneable git repos so that they persist in your setup. More info
+# in https://github.com/appsembler/devstack/pull/42.
+# Example: EDXAPP_EXTRA_REQUIREMENTS="https://github.com/appsembler/gestore.git==0.1.0-dev3,https://github.com/appsembler/course-access-groups.git"
+EDXAPP_EXTRA_REQUIREMENTS=""
+
 # The command that runs all of your devstack services (LMS, Studio, ...) Change it if you have a custom one.
 DEVSTACK_RUN_COMMAND=dev.up
 

--- a/scripts/instance.sh
+++ b/scripts/instance.sh
@@ -167,6 +167,7 @@ deploy() {
           git_repo_url=$DEVSTACK_REPO_URL
           openedx_release=$OPENEDX_RELEASE
           git_repo_branch=$DEVSTACK_REPO_BRANCH
+          extra_requirements=$EDXAPP_EXTRA_REQUIREMENTS
           virtual_env_dir=$VIRTUAL_ENV" &> "$SHELL_OUTPUT"
         success "Your virtual machine has been deployed successfully!"
         message "Run ${BOLD}${CYAN}sultan instance provision${NORMAL}${MAGENTA} to start provisioning your devstack."
@@ -262,6 +263,7 @@ _image_setup() {
       ci_build=$ETC_HOSTS_HACK
       git_repo_url=$DEVSTACK_REPO_URL
       git_repo_branch=$DEVSTACK_REPO_BRANCH
+      extra_requirements=$EDXAPP_EXTRA_REQUIREMENTS
       openedx_release=$OPENEDX_RELEASE
       virtual_env_dir=$VIRTUAL_ENV
       home_dir=$HOME_DIR

--- a/tests/configs.test
+++ b/tests/configs.test
@@ -107,6 +107,13 @@ DEVSTACK_REPO_BRANCH=${DEVSTACK_BRANCH:-juniper}
 # To work on the master branches and latest images, unset OPENEDX_RELEASE or set it to an empty string.
 OPENEDX_RELEASE="juniper.master"
 
+# A comma-separated list of extra requirements to install inside your edxapp. This is an
+# alternative to the EDXAPP_EXTRA_REQUIREMENTS in edX Ansible scripts. At the moment
+# We only support cloneable git repos so that they persist in your setup. More info
+# in https://github.com/appsembler/devstack/pull/42.
+# Example: EDXAPP_EXTRA_REQUIREMENTS="https://github.com/appsembler/gestore.git==0.1.0-dev3,https://github.com/appsembler/course-access-groups.git"
+EDXAPP_EXTRA_REQUIREMENTS=""
+
 # The command that runs all of your devstack services (LMS, Studio, ...) Change it if you have a custom one.
 DEVSTACK_RUN_COMMAND="HOST=devstack.tahoe dev.up"
 


### PR DESCRIPTION
## Change description

Add support to `EDXAPP_EXTRA_REQUIREMENTS`. These requirements are used in production Ansible deployment scripts, but never were incorporated in the devstack. 

@OmarIthawi introduced a way in our devstack ([devstack#42](https://github.com/appsembler/devstack/pull/42)) to install extra pip packages without modifying edx-platform. This PR introduces a new configuration variable (`EDXAPP_EXTRA_REQUIREMENTS`) that utilizes Omar's work, so it won't work on any devstack except Appsembler's, unfortunately.

The configuration variable expects a comma-separated list of pip packages git repos:
```shell
EDXAPP_EXTRA_REQUIREMENTS="https://github.com/appsembler/gestore.git==0.1.0-dev3,https://github.com/appsembler/course-access-groups.git"
```
To specify the version, simply add `==<branch_or_tag>` after the repo link. If no version is specified, we will default to the main branch of the repo.

If the package you're installing is a Django app, then you might need to consider adding the app name to your `ADDL_INSTALLED_APPS` in your lms/cms YAML configs.


> Note
>
> This change is based on #76 (Hence first commit), so I won't be merging it until the PR is approved and merged.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related PRs
- [edx-platform#976](https://github.com/appsembler/edx-platform/pull/976/files)
- [edxapp-envs#4](https://github.com/appsembler/edxapp-envs/pull/4)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
